### PR TITLE
Enable FM Synth by default in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[=========================================================================[
-  Copyright (c) 2022-2025 Pedro López-Cabanillas
+  Copyright (c) 2022-2026 Pedro López-Cabanillas
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.21)
 
 project( sonivox
     LANGUAGES C CXX
-    VERSION 4.0.0.0
+    VERSION 4.0.1.0
 )
 
 # GoogleTest requires at least C++14
@@ -37,7 +37,7 @@ option(NEW_HOST_WRAPPER "Use the new host wrapper" TRUE)
 option(SF2_SUPPORT "Enable SF2 support and float DCF" TRUE)
 option(ZLIB_SUPPORT "Enable XMF ZLIB Unpacker support" TRUE)
 option(EAS_WT_SYNTH "Enable WaveTable Synth" TRUE)
-option(EAS_FM_SYNTH "Enable FM Synth" FALSE)
+option(EAS_FM_SYNTH "Enable FM Synth" TRUE)
 option(INSTALL_DEPENDENCIES "Deploy dependency libraries" FALSE)
 
 if (NOT (EAS_WT_SYNTH OR EAS_FM_SYNTH OR EAS_HYBRID_SYNTH))
@@ -94,7 +94,7 @@ endif()
 
 include(GNUInstallDirs)
 
-set(PROJECT_RELEASE_DATE "December 30, 2025")
+# set(PROJECT_RELEASE_DATE "December 30, 2025")
 
 if (BUILD_TESTING)
     find_package(GTest CONFIG)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ There are two environment variables that you may set before running the tests (m
 
 ## License
 
-Copyright (c) 2022-2025 Pedro López-Cabanillas and others.
+Copyright (c) 2022-2026 Pedro López-Cabanillas and others.
 
 Copyright (c) 2008-2024, The Android Open Source Project.
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 #[=========================================================================[
-  Copyright (c) 2022-2025 Pedro López-Cabanillas
+  Copyright (c) 2022-2026 Pedro López-Cabanillas
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/example/sonivoxrender.1.md
+++ b/example/sonivoxrender.1.md
@@ -123,4 +123,4 @@ See Tickets at GitHub <https://github.com/EnbeddedSynth/sonivox/issues/>
 
 Licensed under the Apache License, Version 2.0
 
-Copyright (c) 2022-2025 Pedro López-Cabanillas and contributors
+Copyright (c) 2022-2026 Pedro López-Cabanillas and contributors

--- a/example/sonivoxrender.c
+++ b/example/sonivoxrender.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025 Pedro López-Cabanillas
+ * Copyright (c) 2022-2026 Pedro López-Cabanillas
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

* Enable FM Synth by default in CMake
* Bump project version to 4.0.1
* Update Copyright years

## Related Issues

Close #10 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

