### PR TITLE
Fix MSYS2 GitHub action

### DIFF
--- a/.github/workflows/win-msys2.yml
+++ b/.github/workflows/win-msys2.yml
@@ -55,6 +55,7 @@ jobs:
       id: tmp
       run: |
         echo "cache_path=$(cygpath -m $TEMP)" >> $GITHUB_OUTPUT
+        echo "dependencies=$(cygpath -m $MSYSTEM_PREFIX/bin)" >> $GITHUB_OUTPUT
 
     - name: '${{ matrix.icon }} Downloading a DLS file for testing'
       uses: ethanjli/cached-download-action@v0.1.3
@@ -70,7 +71,7 @@ jobs:
         cmake -B build -G Ninja
         -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
         -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_LOCATION}}
-        -DDEPENDENCY_DIRS=${{steps.msys2.outputs.msys2-location}}/${{matrix.sys}}/bin
+        -DDEPENDENCY_DIRS=${{steps.tmp.outputs.dependencies}}
         -DCPACK_SYSTEM_NAME=${{matrix.sys}}
         -DINSTALL_DEPENDENCIES=ON
 


### PR DESCRIPTION
## Description

Avoid overriding TEMP environment variable; transform msys2 TEMP using cygpath.

## Related Issues

Closes #18 

## Checklist

- [x] I have followed the contribution guidelines.
- [x] My code follows the coding standards.
- [x] I have tested my changes.

